### PR TITLE
Add plugin which sets the NODE_ENV

### DIFF
--- a/lib/railspack/templates/webpack.js
+++ b/lib/railspack/templates/webpack.js
@@ -10,6 +10,12 @@ module.exports = {
     path: path.join(__dirname, 'app', 'assets', 'javascripts'),
     filename: 'frontend.js'
   },
+  
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development')
+    })
+  ],
 
   module: {
     loaders: [


### PR DESCRIPTION
In production, webpack really wants this set and complains about Redux not using the correct minified version. Speeds up redux, etc.

code from https://stackoverflow.com/questions/30030031/passing-environment-dependent-variables-in-webpack