### PR TITLE
change from querySelector to querySelectorAll

### DIFF
--- a/lib/railspack/templates/registerComponent.js
+++ b/lib/railspack/templates/registerComponent.js
@@ -10,9 +10,11 @@ const getProps = (container) => {
 
 export const registerComponent = (instance, containerName) => {
   const selector = `[data-react-container=${containerName}]`
-  const container = document.querySelector(selector)
-
-  if (container) {
+  const containers = document.querySelectorAll(selector)
+  
+  for (let i = 0; i < containers.length; ++i) {
+    let container = containers[i];
+        
     const props = getProps(container)
     const element = React.createElement(instance, props)
     ReactDOM.render(element, container)


### PR DESCRIPTION
If you had two react-components on a page, it would only register the first one.

This will register each component found on a page. And you can't use `forEach` to iterate, so did a for loop. More info https://css-tricks.com/snippets/javascript/loop-queryselectorall-matches/